### PR TITLE
Add CalcBounds to properly render shapes in editor and blueprint editor

### DIFF
--- a/TraceAndSweepCollision/Source/TraceAndSweepCollision/Public/TraceAndSweepCollisionComponent.h
+++ b/TraceAndSweepCollision/Source/TraceAndSweepCollision/Public/TraceAndSweepCollisionComponent.h
@@ -40,7 +40,11 @@ protected:
 	virtual void TickComponent(float delta_time, ELevelTick tick_type, FActorComponentTickFunction* this_tick_function) override;
 	virtual FPrimitiveSceneProxy* CreateSceneProxy() override;
 	// End UPrimitiveComponent overrides
-	
+
+	//~ Begin USceneComponent Interface
+	virtual FBoxSphereBounds CalcBounds(const FTransform& LocalToWorld) const override;
+	// virtual void CalcBoundingCylinder(float& CylinderRadius, float& CylinderHalfHeight) const override;
+	//~ End USceneComponent Interface
 private:
 	// Wrapper for FHitResult since FHitResult doesn't have == operator
 	struct FHitResultWrapper


### PR DESCRIPTION
After looking into the issue with the shapes not showing up in the editor, I tried a lot of things and this ended up fixing it for me. I'm not sure if there's any other side effects of overriding the CalcBounds but I'm wondering why this worked before without this.