### PR TITLE
Adding CalcBounds function

### DIFF
--- a/TraceAndSweepCollision/Source/TraceAndSweepCollision/Public/TraceAndSweepCollisionComponent.h
+++ b/TraceAndSweepCollision/Source/TraceAndSweepCollision/Public/TraceAndSweepCollisionComponent.h
@@ -41,6 +41,9 @@ protected:
 	virtual FPrimitiveSceneProxy* CreateSceneProxy() override;
 	// End UPrimitiveComponent overrides
 	
+	//~ Begin USceneComponent Interface
+	virtual FBoxSphereBounds CalcBounds(const FTransform& LocalToWorld) const override;
+	//~ End USceneComponent Interface
 private:
 	// Wrapper for FHitResult since FHitResult doesn't have == operator
 	struct FHitResultWrapper


### PR DESCRIPTION
Unreal uses CalcBounds function to check if the FPrimitiveSceneProxy should be shown or not. So calculating the exact bounds based on all the shapes is necessary.

When using scene objects in line trace mode, it still not perfect and sometimes doesn't draw debug lines.